### PR TITLE
Capitalise provider name in docs index file frontmatter description.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ category: ["saas"]
 brand_color: "#18BFFF"
 display_name: "Airtable"
 short_name: "Airtable"
-description: "Steampipe plugin for querying airtable."
+description: "Steampipe plugin for querying Airtable."
 og_description: "Query Airtable with SQL! Open source CLI. No DB required."
 icon_url: "/images/plugins/francois2metz/airtable.svg"
 og_image: "/images/plugins/francois2metz/airtable-social-graphic.png"


### PR DESCRIPTION
Hey @francois2metz,

Really minor one, but I noticed that the provider name in the docs frontmatter index file wasn't capitalised like we have on other services. I thought worth raising a PR in case you have any other releases planned for the plugin.

Cheers,
Mike.