### PR TITLE
Bump steampipe-plugin-sdk to v1.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/iancoleman/strcase v0.2.0
 	github.com/mehanizm/airtable v0.2.4
-	github.com/turbot/steampipe-plugin-sdk v1.7.0
+	github.com/turbot/steampipe-plugin-sdk v1.7.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/tkrajina/go-reflector v0.5.4 h1:dS9aJEa/eYNQU/fwsb5CSiATOxcNyA/gG/A7a
 github.com/tkrajina/go-reflector v0.5.4/go.mod h1:9PyLgEOzc78ey/JmQQHbW8cQJ1oucLlNQsg8yFvkVk8=
 github.com/turbot/go-kit v0.3.0 h1:o4zZIO1ovdmJ2bHWOdXnnt8jJMIDGqYSkZvBREzFeMQ=
 github.com/turbot/go-kit v0.3.0/go.mod h1:SBdPRngbEfYubiR81iAVtO43oPkg1+ASr+XxvgbH7/k=
-github.com/turbot/steampipe-plugin-sdk v1.7.0 h1:84OFfUoxgMXHb51tPMtkabnIuADw3hAA07Ye4+dTAFY=
-github.com/turbot/steampipe-plugin-sdk v1.7.0/go.mod h1:y7q8abyaXXQNzwE9l4Tn/gkEnvmcyPpyedpHF04wggs=
+github.com/turbot/steampipe-plugin-sdk v1.7.2 h1:+7KHu5EPryOmvDp1A9kHlH/muOVkVm+pDnwqES3kM+Q=
+github.com/turbot/steampipe-plugin-sdk v1.7.2/go.mod h1:y7q8abyaXXQNzwE9l4Tn/gkEnvmcyPpyedpHF04wggs=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=


### PR DESCRIPTION
Hey @francois2metz , we recently released a new SDK version that includes some fixes when `TableMapFunc` is used in `plugin.go` ([CHANGELOG for v1.7.2](https://github.com/turbot/steampipe-plugin-sdk/blob/main/CHANGELOG.md#v172--2021-11-03)).

Please let me know if you have any questions, thanks!