### PR TITLE
Fix the plugin initialization error when the API token is not set in the .spc file

### DIFF
--- a/airtable/plugin.go
+++ b/airtable/plugin.go
@@ -27,7 +27,7 @@ func PluginTables(ctx context.Context, d *plugin.TableMapData) (map[string]*plug
 	client, err := rawConnect(ctx, d.Connection, d.ConnectionCache)
 	if err != nil {
 		plugin.Logger(ctx).Error("airtable.init", "connection_error", err)
-		return nil, err
+		return tableMap, nil
 	}
 
 	bases := client.GetBases()

--- a/airtable/utils.go
+++ b/airtable/utils.go
@@ -25,6 +25,7 @@ func rawConnect(ctx context.Context, connection *plugin.Connection, connectionca
 	if airtableConfig.Token != nil {
 		token = *airtableConfig.Token
 	}
+	
 	if token == "" {
 		return nil, errors.New("'token' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe")
 	}


### PR DESCRIPTION
Steampipe CLI version: `v0.21.4`
Plugin version: `v0.5.0`

After installing the Airtable plugin, when I run `steampipe query` without setting the `token` parameter in the `airtable.spc` file, I get the following warning - 

```
Warning: failed to start plugin instance 'hub.steampipe.io/plugins/francois2metz/airtable@latest': 'token' must be set in the connection configuration. Edit your connection configuration file and then restart Steampipe
```

This PR aims at returning `nil` instead of an error when the token parameter is not set.